### PR TITLE
feat: Implement Phase 2 Teacher Resource Management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from './contexts/AuthContext';
 import Navbar from './components/layout/Navbar';
 import Footer from './components/layout/Footer';
 import ProtectedRoute from './components/auth/ProtectedRoute';
+import TeacherProtectedRoute from './components/auth/TeacherProtectedRoute'; // Import TeacherProtectedRoute
 
 // Pages
 import HomePage from './pages/HomePage';
@@ -11,7 +12,10 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ProfilePage from './pages/ProfilePage';
 import CourseListPage from './pages/CourseListPage';
-import CourseDetailPage from './pages/CourseDetailPage'; // Import CourseDetailPage
+import CourseDetailPage from './pages/CourseDetailPage';
+import MyResourcesPage from './pages/teacher/MyResourcesPage';
+import ResourceFormPage from './pages/teacher/ResourceFormPage';
+import ManageChapterContentPage from './pages/teacher/ManageChapterContentPage'; // Import ManageChapterContentPage
 
 // Layout component to include Navbar and Footer
 const AppLayout: React.FC = () => {
@@ -42,7 +46,29 @@ function App() {
                 <ProfilePage />
               </ProtectedRoute>
             } />
-            {/* Add other routes here */}
+            {/* Teacher specific routes */}
+            <Route path="/teacher/resources" element={
+              <TeacherProtectedRoute>
+                <MyResourcesPage />
+              </TeacherProtectedRoute>
+            } />
+            {/* Add other routes here, e.g., /teacher/resources/new, /teacher/resources/edit/:id */}
+            {/* For now, /teacher/resources/new will be a placeholder until its page is created */}
+             <Route path="/teacher/resources/new" element={
+              <TeacherProtectedRoute>
+                <ResourceFormPage />
+              </TeacherProtectedRoute>
+            } />
+             <Route path="/teacher/resources/edit/:resourceId" element={
+              <TeacherProtectedRoute>
+                <ResourceFormPage />
+              </TeacherProtectedRoute>
+            } />
+            <Route path="/teacher/courses/:courseId/chapters/:chapterId/manage-content" element={
+              <TeacherProtectedRoute>
+                <ManageChapterContentPage />
+              </TeacherProtectedRoute>
+            } />
           </Route>
         </Routes>
       </Router>

--- a/client/src/components/auth/TeacherProtectedRoute.tsx
+++ b/client/src/components/auth/TeacherProtectedRoute.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+
+const TeacherProtectedRoute: React.FC = () => {
+  const { isAuthenticated, user, isLoading } = useAuth();
+  const location = useLocation();
+
+  if (isLoading) {
+    return <div>Loading authentication status...</div>;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (user?.role !== 'teacher') {
+    // If authenticated but not a teacher, redirect to a general page (e.g., home or an unauthorized page)
+    // Or display an "Unauthorized" message inline.
+    // For this example, redirecting to home.
+    alert('You are not authorized to access this page.'); // Optional: alert before redirect
+    return <Navigate to="/" state={{ from: location }} replace />;
+  }
+
+  return <Outlet />; // Render child components if authenticated and is a teacher
+};
+
+export default TeacherProtectedRoute;

--- a/client/src/components/layout/Navbar.tsx
+++ b/client/src/components/layout/Navbar.tsx
@@ -16,12 +16,15 @@ const Navbar: React.FC = () => {
       <div>
         <Link to="/" style={{ marginRight: '1rem' }}>Home</Link>
         <Link to="/courses" style={{ marginRight: '1rem' }}>Courses</Link>
+        {user?.role === 'teacher' && (
+          <Link to="/teacher/resources" style={{ marginRight: '1rem' }}>My Resources</Link>
+        )}
       </div>
       <div>
         {isAuthenticated ? (
           <>
             <span style={{ marginRight: '1rem' }}>
-              Welcome, {user?.firstName || user?.username}!
+              Welcome, {user?.firstName || user?.username}! (Role: {user?.role})
             </span>
             <Link to="/profile" style={{ marginRight: '1rem' }}>Profile</Link>
             <button onClick={handleLogout}>Logout</button>

--- a/client/src/pages/CourseDetailPage.tsx
+++ b/client/src/pages/CourseDetailPage.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom'; // Import Link
 import { getCourseById } from '../../services/courseService';
-import { Course } from '../../types/course'; // Chapter type is implicitly used by Course.chapters
-import ChapterListItem from '../../components/courses/ChapterListItem'; // Import ChapterListItem
+import { Course, Chapter as ChapterType } from '../../types/course'; // Explicitly import ChapterType
+import { useAuth } from '../../contexts/AuthContext'; // Import useAuth
+import ChapterListItem from '../../components/courses/ChapterListItem';
 
 // Basic styling (can be moved to a CSS file)
 const styles: { [key: string]: React.CSSProperties } = {
@@ -39,6 +40,23 @@ const styles: { [key: string]: React.CSSProperties } = {
     listStyle: 'none',
     padding: 0,
   },
+  chapterManagementItem: { // Style for the li containing ChapterListItem and Manage button
+    marginBottom: '10px',
+    padding: '10px',
+    border: '1px solid #f0f0f0',
+    borderRadius: '4px',
+    backgroundColor: '#fafafa',
+  },
+  manageButton: {
+    marginTop: '10px',
+    padding: '8px 12px',
+    backgroundColor: '#007bff',
+    color: 'white',
+    textDecoration: 'none',
+    borderRadius: '4px',
+    display: 'inline-block', // To allow margin-top
+    fontSize: '0.9rem',
+  },
   // chapterListItem, chapterTitle, chapterContentPreview can be removed if fully handled by ChapterListItem
   loading: {
     textAlign: 'center',
@@ -58,6 +76,7 @@ const CourseDetailPage: React.FC = () => {
   const [course, setCourse] = useState<Course | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { user } = useAuth(); // Get current user from AuthContext
 
   useEffect(() => {
     if (!courseId) {
@@ -114,8 +133,18 @@ const CourseDetailPage: React.FC = () => {
           <ul style={styles.chapterList}>
             {course.chapters
               .sort((a, b) => a.order - b.order)
-              .map((chapter, index) => (
-                <ChapterListItem key={chapter.id} chapter={chapter} index={index} />
+              .map((chapter: ChapterType, index) => ( // Use ChapterType for clarity
+                <li key={chapter.id} style={styles.chapterManagementItem}>
+                  <ChapterListItem chapter={chapter} index={index} />
+                  {user && user.role === 'teacher' && course.teacherId === user.id && (
+                    <Link
+                      to={`/teacher/courses/${course.id}/chapters/${chapter.id}/manage-content`}
+                      style={styles.manageButton}
+                    >
+                      Manage Content
+                    </Link>
+                  )}
+                </li>
               ))}
           </ul>
         ) : (

--- a/client/src/pages/teacher/ManageChapterContentPage.test.tsx
+++ b/client/src/pages/teacher/ManageChapterContentPage.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { AuthContext, AuthContextType } from '../../contexts/AuthContext';
+import ManageChapterContentPage from './ManageChapterContentPage';
+import * as resourceService from '../../services/resourceService';
+import * as courseService from '../../services/courseService'; // For getCourseById
+import { Resource, ResourceType } from '../../types/resource';
+import { Course, Chapter } from '../../types/course';
+
+jest.mock('../../services/resourceService');
+const mockedResourceService = resourceService as jest.Mocked<typeof resourceService>;
+
+jest.mock('../../services/courseService');
+const mockedCourseService = courseService as jest.Mocked<typeof courseService>;
+
+const mockTeacherUser = {
+  id: 1, username: 'teacher1', email: 'teacher@example.com', role: 'teacher',
+};
+
+const mockCourse: Course = {
+  id: 1, title: 'Test Course', teacherId: 1, chapters: [
+    { id: 1, title: 'Chapter 1: Intro', order: 1, content: '', courseId: 1, createdAt: '', updatedAt: '' },
+    { id: 2, title: 'Chapter 2: Deep Dive', order: 2, content: '', courseId: 1, createdAt: '', updatedAt: '' },
+  ], createdAt: '', updatedAt: '',
+};
+
+const mockLinkedResources: Resource[] = [
+  { id: 'res1', title: 'Linked Resource A', type: ResourceType.MARKDOWN, teacherId:1, createdAt: '', updatedAt: '' },
+  { id: 'res2', title: 'Linked Resource B', type: ResourceType.VIDEO_URL, teacherId:1, createdAt: '', updatedAt: '' },
+];
+
+const renderPage = (authContextValue: Partial<AuthContextType>, courseId: string, chapterId: string) => {
+  return render(
+    <AuthContext.Provider value={authContextValue as AuthContextType}>
+      <MemoryRouter initialEntries={[`/teacher/courses/${courseId}/chapters/${chapterId}/manage-content`]}>
+        <Routes>
+          <Route path="/teacher/courses/:courseId/chapters/:chapterId/manage-content" element={<ManageChapterContentPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+};
+
+describe('ManageChapterContentPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCourseService.getCourseById.mockResolvedValue(mockCourse);
+    mockedResourceService.getResourcesForChapter.mockResolvedValue(mockLinkedResources);
+  });
+
+  it('fetches and displays course, chapter, and linked resource information', async () => {
+    renderPage({ user: mockTeacherUser, isLoading: false }, '1', '1');
+
+    await waitFor(() => {
+      expect(mockedCourseService.getCourseById).toHaveBeenCalledWith('1');
+      expect(mockedResourceService.getResourcesForChapter).toHaveBeenCalledWith('1', '1');
+    });
+
+    expect(screen.getByText(`Back to Course: ${mockCourse.title}`)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: `Manage Content for Chapter: ${mockCourse.chapters[0].title}`})).toBeInTheDocument();
+
+    expect(screen.getByText('Linked Resource A')).toBeInTheDocument();
+    expect(screen.getByText('Type: markdown')).toBeInTheDocument();
+    expect(screen.getByText('Linked Resource B')).toBeInTheDocument();
+    expect(screen.getByText('Type: video_url')).toBeInTheDocument();
+  });
+
+  it('displays "no resources" message if chapter has no linked resources', async () => {
+    mockedResourceService.getResourcesForChapter.mockResolvedValue([]);
+    renderPage({ user: mockTeacherUser, isLoading: false }, '1', '1');
+
+    await waitFor(() => expect(mockedResourceService.getResourcesForChapter).toHaveBeenCalled());
+    expect(screen.getByText('No resources added to this chapter yet.')).toBeInTheDocument();
+  });
+
+  it('handles error when fetching course details', async () => {
+    mockedCourseService.getCourseById.mockRejectedValue(new Error('Failed to fetch course'));
+    renderPage({ user: mockTeacherUser, isLoading: false }, '1', '1');
+
+    await waitFor(() => expect(screen.getByText(/Failed to load data for managing chapter content./i)).toBeInTheDocument());
+  });
+
+  it('handles error when fetching linked resources', async () => {
+    mockedResourceService.getResourcesForChapter.mockRejectedValue(new Error('Failed to fetch resources'));
+    renderPage({ user: mockTeacherUser, isLoading: false }, '1', '1');
+
+    await waitFor(() => expect(screen.getByText(/Failed to load data for managing chapter content./i)).toBeInTheDocument());
+  });
+
+  it('shows unauthorized message if user is not a teacher', async () => {
+    renderPage({ user: { ...mockTeacherUser, role: 'student'}, isLoading: false }, '1', '1');
+    // The fetchData useEffect might not run if role check happens first,
+    // but the component itself has a role check.
+    await waitFor(() => expect(screen.getByText('You are not authorized to manage this content.')).toBeInTheDocument());
+  });
+
+  it('displays placeholder buttons for actions', async () => {
+    renderPage({ user: mockTeacherUser, isLoading: false }, '1', '1');
+    await waitFor(() => expect(mockedResourceService.getResourcesForChapter).toHaveBeenCalled());
+
+    expect(screen.getByRole('button', { name: /add existing resource/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /create new resource for this chapter/i })).toBeInTheDocument();
+    expect(screen.getByText(/reordering and removal functionality will be implemented here./i)).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/teacher/ManageChapterContentPage.tsx
+++ b/client/src/pages/teacher/ManageChapterContentPage.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { getResourcesForChapter } from '../../services/resourceService';
+import { getCourseById } from '../../services/courseService'; // To get course title
+import { Resource, ResourceType } from '../../types/resource';
+import { Course, Chapter } from '../../types/course'; // Assuming Chapter type is here
+import { useAuth } from '../../contexts/AuthContext';
+
+const styles: { [key: string]: React.CSSProperties } = {
+  page: { padding: '20px', fontFamily: 'Arial, sans-serif' },
+  header: { marginBottom: '20px' },
+  courseTitle: { fontSize: '1.2rem', color: '#555', marginBottom: '5px' },
+  chapterTitle: { fontSize: '1.8rem', margin: '0 0 20px 0'},
+  resourceList: { listStyle: 'none', padding: 0 },
+  resourceItem: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '10px',
+    border: '1px solid #eee',
+    borderRadius: '4px',
+    marginBottom: '10px'
+  },
+  resourceInfo: {},
+  resourceTitle: { fontSize: '1.1rem', margin: '0 0 5px 0' },
+  resourceType: { fontSize: '0.9rem', color: '#777' },
+  actionsPlaceholder: { marginTop: '20px', borderTop: '1px dashed #ccc', paddingTop: '20px' },
+  addButton: {
+    padding: '10px 15px',
+    fontSize: '1rem',
+    backgroundColor: '#28a745',
+    color: 'white',
+    border: 'none',
+    borderRadius: '5px',
+    cursor: 'pointer',
+    textDecoration: 'none',
+    marginRight: '10px',
+  },
+  loading: { textAlign: 'center', fontSize: '1.2rem', marginTop: '50px' },
+  error: { textAlign: 'center', color: 'red', fontSize: '1.2rem', marginTop: '50px' },
+};
+
+const ManageChapterContentPage: React.FC = () => {
+  const { courseId, chapterId } = useParams<{ courseId: string; chapterId: string }>();
+  const [course, setCourse] = useState<Course | null>(null);
+  const [chapter, setChapter] = useState<Chapter | null>(null); // For chapter title
+  const [linkedResources, setLinkedResources] = useState<Resource[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (!courseId || !chapterId) {
+      setError("Course or Chapter ID missing from URL.");
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchData = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        // Fetch course details (for title and to find specific chapter title)
+        const courseData = await getCourseById(courseId);
+        setCourse(courseData);
+        const currentChapter = courseData.chapters?.find(c => c.id.toString() === chapterId);
+        setChapter(currentChapter || null);
+        if (!currentChapter) {
+            throw new Error("Chapter not found in the course.");
+        }
+
+        // Fetch resources linked to this chapter
+        const resourcesData = await getResourcesForChapter(courseId, chapterId);
+        setLinkedResources(resourcesData);
+
+      } catch (err: any) {
+        console.error("Error fetching chapter content data:", err);
+        setError(err.message || "Failed to load data for managing chapter content.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [courseId, chapterId]);
+
+  // Basic role check, TeacherProtectedRoute should handle primary guarding
+  if (user?.role !== 'teacher') {
+    return <div style={styles.error}>You are not authorized to manage this content.</div>;
+  }
+
+
+  if (isLoading) {
+    return <div style={styles.loading}>Loading chapter content management...</div>;
+  }
+
+  if (error) {
+    return <div style={styles.error}>{error}</div>;
+  }
+
+  if (!course || !chapter) {
+    return <div style={styles.error}>Course or Chapter details could not be loaded.</div>;
+  }
+
+
+  return (
+    <div style={styles.page}>
+      <header style={styles.header}>
+        <Link to={`/courses/${courseId}`} style={styles.courseTitle}>Back to Course: {course?.title}</Link>
+        <h1 style={styles.chapterTitle}>Manage Content for Chapter: {chapter?.title}</h1>
+      </header>
+
+      <div>
+        <h3>Currently Linked Resources:</h3>
+        {linkedResources.length === 0 ? (
+          <p>No resources added to this chapter yet.</p>
+        ) : (
+          <ul style={styles.resourceList}>
+            {linkedResources.map(resource => (
+              <li key={resource.id} style={styles.resourceItem}>
+                <div style={styles.resourceInfo}>
+                  <h4 style={styles.resourceTitle}>{resource.title}</h4>
+                  <p style={styles.resourceType}>Type: {resource.type}</p>
+                </div>
+                {/* Placeholder for Remove/Reorder controls */}
+                <div>
+                  <button disabled style={{marginRight: '5px'}}>Reorder</button>
+                  <button disabled>Remove</button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div style={styles.actionsPlaceholder}>
+        <h3>Manage Resources</h3>
+        <button style={styles.addButton} disabled>Add Existing Resource</button>
+        {/* Above button could link to /teacher/resources to select one, or a modal */}
+        <Link to={`/teacher/resources/new?courseId=${courseId}&chapterId=${chapterId}`} style={styles.addButton}>
+            Create New Resource for this Chapter
+        </Link>
+        <p style={{marginTop: '10px'}}><small>Reordering and removal functionality will be implemented here.</small></p>
+      </div>
+    </div>
+  );
+};
+
+export default ManageChapterContentPage;

--- a/client/src/pages/teacher/MyResourcesPage.test.tsx
+++ b/client/src/pages/teacher/MyResourcesPage.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthContext, AuthContextType } from '../../contexts/AuthContext';
+import MyResourcesPage from './MyResourcesPage';
+import * as resourceService from '../../services/resourceService'; // To mock getMyResources & deleteResource
+
+// Mock resourceService
+jest.mock('../../services/resourceService');
+const mockedResourceService = resourceService as jest.Mocked<typeof resourceService>;
+
+// Mock useNavigate
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockTeacherUser = {
+  id: 1,
+  username: 'teacher1',
+  email: 'teacher@example.com',
+  role: 'teacher',
+  firstName: 'Test',
+  lastName: 'Teacher',
+};
+
+const mockStudentUser = {
+  id: 2,
+  username: 'student1',
+  email: 'student@example.com',
+  role: 'student',
+};
+
+const mockResources = [
+  { id: 'res1', title: 'Resource Alpha', type: 'markdown', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), teacherId: 1 },
+  { id: 'res2', title: 'Resource Beta', type: 'video_url', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), teacherId: 1 },
+];
+
+const renderPage = (authContextValue: Partial<AuthContextType>) => {
+  return render(
+    <AuthContext.Provider value={authContextValue as AuthContextType}>
+      <BrowserRouter>
+        <MyResourcesPage />
+      </BrowserRouter>
+    </AuthContext.Provider>
+  );
+};
+
+describe('MyResourcesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock window.confirm
+    window.confirm = jest.fn(() => true); // Default to user confirming delete
+  });
+
+  it('redirects if user is not a teacher', () => {
+    renderPage({ user: mockStudentUser, isLoading: false });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('fetches and displays resources for a teacher', async () => {
+    mockedResourceService.getMyResources.mockResolvedValue(mockResources);
+    renderPage({ user: mockTeacherUser, isLoading: false });
+
+    expect(screen.getByText('Loading your resources...')).toBeInTheDocument();
+    await waitFor(() => expect(mockedResourceService.getMyResources).toHaveBeenCalledTimes(1));
+
+    expect(screen.getByText('Resource Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Resource Beta')).toBeInTheDocument();
+    expect(screen.getByText('Create New Resource')).toBeInTheDocument(); // Button
+  });
+
+  it('shows "no resources" message if none are found', async () => {
+    mockedResourceService.getMyResources.mockResolvedValue([]);
+    renderPage({ user: mockTeacherUser, isLoading: false });
+
+    await waitFor(() => expect(mockedResourceService.getMyResources).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("You haven't created any resources yet.")).toBeInTheDocument();
+  });
+
+  it('handles error when fetching resources', async () => {
+    mockedResourceService.getMyResources.mockRejectedValue(new Error('Failed to fetch'));
+    renderPage({ user: mockTeacherUser, isLoading: false });
+
+    await waitFor(() => expect(mockedResourceService.getMyResources).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Failed to fetch resources.')).toBeInTheDocument();
+  });
+
+  it('navigates to create new resource page on button click', async () => {
+    mockedResourceService.getMyResources.mockResolvedValue([]);
+    renderPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => {}); // Ensure page is loaded
+
+    fireEvent.click(screen.getByText('Create New Resource'));
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher/resources/new'); // Assuming Link uses navigate internally or test Link component
+  });
+
+  it('navigates to edit page on "Edit" button click', async () => {
+    mockedResourceService.getMyResources.mockResolvedValue([mockResources[0]]);
+    renderPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => screen.getByText('Resource Alpha'));
+
+    const editButtons = screen.getAllByRole('button', { name: /edit/i });
+    fireEvent.click(editButtons[0]);
+    expect(mockNavigate).toHaveBeenCalledWith(`/teacher/resources/edit/${mockResources[0].id}`);
+  });
+
+
+  it('calls deleteResource and updates UI on confirmed delete', async () => {
+    mockedResourceService.getMyResources.mockResolvedValue([...mockResources]);
+    mockedResourceService.deleteResource.mockResolvedValue(undefined); // Successful delete
+
+    renderPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => expect(screen.getByText('Resource Alpha')).toBeInTheDocument());
+
+    const deleteButtons = screen.getAllByRole('button', { name: /delete/i });
+    fireEvent.click(deleteButtons[0]); // Click delete for "Resource Alpha"
+
+    expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to delete the resource "Resource Alpha"?');
+    expect(mockedResourceService.deleteResource).toHaveBeenCalledWith('res1');
+
+    await waitFor(() => expect(screen.queryByText('Resource Alpha')).not.toBeInTheDocument());
+    expect(screen.getByText('Resource "Resource Alpha" deleted successfully.')).toBeInTheDocument();
+    expect(screen.getByText('Resource Beta')).toBeInTheDocument(); // Ensure other resource is still there
+  });
+
+  it('does not call deleteResource if confirmation is cancelled', async () => {
+    (window.confirm as jest.Mock).mockReturnValueOnce(false); // User cancels delete
+    mockedResourceService.getMyResources.mockResolvedValue([mockResources[0]]);
+    renderPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => screen.getByText('Resource Alpha'));
+
+    const deleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+    fireEvent.click(deleteButton);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(mockedResourceService.deleteResource).not.toHaveBeenCalled();
+    expect(screen.getByText('Resource Alpha')).toBeInTheDocument(); // Resource still present
+  });
+
+  it('shows error message on delete failure', async () => {
+    mockedResourceService.getMyResources.mockResolvedValue([mockResources[0]]);
+    mockedResourceService.deleteResource.mockRejectedValue(new Error('Deletion failed'));
+    renderPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => screen.getByText('Resource Alpha'));
+
+    const deleteButton = screen.getAllByRole('button', { name: /delete/i })[0];
+    fireEvent.click(deleteButton);
+
+    expect(window.confirm).toHaveBeenCalled();
+    expect(mockedResourceService.deleteResource).toHaveBeenCalledWith('res1');
+    await waitFor(() => expect(screen.getByText('Error: Failed to delete resource.')).toBeInTheDocument());
+  });
+});

--- a/client/src/pages/teacher/MyResourcesPage.tsx
+++ b/client/src/pages/teacher/MyResourcesPage.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { getMyResources, deleteResource } from '../../services/resourceService'; // Import deleteResource
+import { Resource } from '../../types/resource'; // Import Resource type
+import { useAuth } from '../../contexts/AuthContext';
+
+// Basic styling (can be moved to a CSS file)
+const styles: { [key: string]: React.CSSProperties } = {
+  page: { padding: '20px', fontFamily: 'Arial, sans-serif' },
+  header: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '20px' },
+  title: { fontSize: '2rem', margin: 0 },
+  createButton: {
+    padding: '10px 15px',
+    fontSize: '1rem',
+    backgroundColor: '#007bff',
+    color: 'white',
+    border: 'none',
+    borderRadius: '5px',
+    cursor: 'pointer',
+    textDecoration: 'none',
+  },
+  resourceTable: { width: '100%', borderCollapse: 'collapse', marginTop: '20px' },
+  tableHeader: { backgroundColor: '#f0f0f0' },
+  tableCell: { border: '1px solid #ddd', padding: '8px', textAlign: 'left' },
+  actionsCell: { display: 'flex', gap: '10px'},
+  actionButton: { padding: '5px 10px', fontSize: '0.9rem', border: 'none', borderRadius: '3px', cursor: 'pointer' },
+  editButton: { backgroundColor: '#ffc107' },
+  deleteButton: { backgroundColor: '#dc3545', color: 'white' },
+  loading: { textAlign: 'center', fontSize: '1.2rem', marginTop: '50px' },
+  error: { textAlign: 'center', color: 'red', fontSize: '1.2rem', marginTop: '50px' },
+  noResources: { textAlign: 'center', fontSize: '1.1rem', marginTop: '30px' }
+};
+
+
+const MyResourcesPage: React.FC = () => {
+  const [resources, setResources] = useState<Resource[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDeleting, setIsDeleting] = useState(false); // For delete operation loading state
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null); // For success notifications
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user?.role !== 'teacher') {
+      // This is a fallback, route protection should ideally handle this.
+      // Or, display a message "You are not authorized to view this page."
+      navigate('/'); // Redirect to home if not a teacher
+      return;
+    }
+
+    const fetchResources = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        setSuccessMessage(null); // Clear previous success messages
+        const data = await getMyResources(); // Use actual service call
+        setResources(data);
+      } catch (err: any) {
+        setError(err.message || 'Failed to fetch resources.');
+        console.error(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (user?.role === 'teacher') { // Fetch only if user is confirmed as teacher
+        fetchResources();
+    } else if (user && user.role !== 'teacher') { // If user is loaded but not teacher
+        navigate('/');
+        setIsLoading(false); // Stop loading as we are redirecting
+    }
+    // If user is null (still loading from AuthContext), useEffect will re-run when user state changes.
+  }, [user, navigate]);
+
+  const handleDeleteResource = async (resourceId: string, resourceTitle: string) => {
+    if (window.confirm(`Are you sure you want to delete the resource "${resourceTitle}"?`)) {
+      setIsDeleting(true);
+      setError(null);
+      setSuccessMessage(null);
+      try {
+        await deleteResource(resourceId);
+        setResources(prevResources => prevResources.filter(res => res.id !== resourceId));
+        setSuccessMessage(`Resource "${resourceTitle}" deleted successfully.`);
+      } catch (err: any) {
+        setError(err.response?.data?.message || err.message || 'Failed to delete resource.');
+        console.error("Delete error:", err);
+      } finally {
+        setIsDeleting(false);
+      }
+    }
+  };
+
+  if (isLoading) { // Initial page load
+    return <div style={styles.loading}>Loading your resources...</div>;
+  }
+
+  // This error is for initial fetch. Delete errors are handled inline or via success/error messages.
+  if (error && !isDeleting) { // Show general fetch error if not in midst of deleting
+    return <div style={styles.error}>{error}</div>;
+  }
+
+  // Fallback if user somehow lands here without being a teacher
+  if (user?.role !== 'teacher') {
+    return <div style={styles.error}>You are not authorized to view this page.</div>;
+  }
+
+  return (
+    <div style={styles.page}>
+      <header style={styles.header}>
+        <h1 style={styles.title}>My Resources</h1>
+        <Link to="/teacher/resources/new" style={styles.createButton}>
+          Create New Resource
+        </Link>
+      </header>
+
+      {/* Display success or error messages related to delete operations */}
+      {successMessage && <p style={{ color: 'green', textAlign: 'center' }}>{successMessage}</p>}
+      {error && isDeleting && <p style={{ color: 'red', textAlign: 'center' }}>Error: {error}</p>}
+
+
+      {resources.length === 0 ? (
+        <p style={styles.noResources}>You haven't created any resources yet.</p>
+      ) : (
+        <table style={styles.resourceTable}>
+          <thead style={styles.tableHeader}>
+            <tr>
+              <th style={styles.tableCell}>Title</th>
+              <th style={styles.tableCell}>Type</th>
+              <th style={styles.tableCell}>Created At</th>
+              <th style={styles.tableCell}>Last Updated</th>
+              <th style={styles.tableCell}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {resources.map((resource) => (
+              <tr key={resource.id}>
+                <td style={styles.tableCell}>{resource.title}</td>
+                <td style={styles.tableCell}>{resource.type}</td>
+                <td style={styles.tableCell}>{new Date(resource.createdAt).toLocaleDateString()}</td>
+                <td style={styles.tableCell}>{new Date(resource.updatedAt).toLocaleDateString()}</td>
+                <td style={{...styles.tableCell, ...styles.actionsCell}}>
+                  <button
+                    style={{...styles.actionButton, ...styles.editButton}}
+                    onClick={() => navigate(`/teacher/resources/edit/${resource.id}`)}
+                    disabled={isDeleting} // Disable edit while a delete is in progress
+                  >
+                    Edit
+                  </button>
+                  <button
+                    style={{...styles.actionButton, ...styles.deleteButton}}
+                    onClick={() => handleDeleteResource(resource.id, resource.title)}
+                    disabled={isDeleting} // Prevent multiple delete clicks
+                  >
+                    {isDeleting ? 'Deleting...' : 'Delete'}
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default MyResourcesPage;

--- a/client/src/pages/teacher/ResourceFormPage.test.tsx
+++ b/client/src/pages/teacher/ResourceFormPage.test.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter, MemoryRouter, Routes, Route } from 'react-router-dom';
+import { AuthContext, AuthContextType } from '../../contexts/AuthContext';
+import ResourceFormPage from './ResourceFormPage';
+import * as resourceService from '../../services/resourceService';
+import { ResourceType, Resource, Tag } from '../../types/resource';
+
+jest.mock('../../services/resourceService');
+const mockedResourceService = resourceService as jest.Mocked<typeof resourceService>;
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: jest.fn(), // Will be mocked per test case
+}));
+
+const mockTeacherUser = {
+  id: 1, username: 'teacher1', email: 'teacher@example.com', role: 'teacher',
+  firstName: 'Test', lastName: 'Teacher',
+};
+
+const mockAvailableTags: Tag[] = [
+  { id: 1, name: 'TagA' },
+  { id: 2, name: 'TagB' },
+];
+
+const mockResource: Resource = {
+  id: 'res1', title: 'Existing Resource', type: ResourceType.MARKDOWN,
+  content_data: 'Some markdown content', teacherId: 1,
+  tags: [mockAvailableTags[0]], // TagA
+  createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+};
+
+const renderFormPage = (authContextValue: Partial<AuthContextType>, resourceId?: string) => {
+  // Mock useParams for this render
+  jest.spyOn(require('react-router-dom'), 'useParams').mockReturnValue({ resourceId });
+
+  return render(
+    <AuthContext.Provider value={authContextValue as AuthContextType}>
+        <MemoryRouter initialEntries={resourceId ? [`/teacher/resources/edit/${resourceId}`] : ['/teacher/resources/new']}>
+            <Routes>
+                <Route path={resourceId ? "/teacher/resources/edit/:resourceId" : "/teacher/resources/new"} element={<ResourceFormPage />} />
+            </Routes>
+        </MemoryRouter>
+    </AuthContext.Provider>
+  );
+};
+
+describe('ResourceFormPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedResourceService.getAllTags.mockResolvedValue(mockAvailableTags);
+    mockedResourceService.getResourceById.mockResolvedValue(mockResource);
+    mockedResourceService.createResource.mockResolvedValue(mockResource); // Mock create
+    mockedResourceService.updateResource.mockResolvedValue(mockResource); // Mock update
+  });
+
+  it('renders in create mode with empty fields', async () => {
+    renderFormPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => expect(mockedResourceService.getAllTags).toHaveBeenCalled());
+
+    expect(screen.getByRole('heading', { name: /create new resource/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toHaveValue('');
+    expect(screen.getByLabelText(/type/i)).toHaveValue(ResourceType.TEXT); // Default
+    expect(screen.getByLabelText(/content data/i)).toHaveValue('');
+    expect(screen.getByText('TagA')).toBeInTheDocument(); // Check if tags are rendered
+  });
+
+  it('renders in edit mode and populates form with resource data', async () => {
+    renderFormPage({ user: mockTeacherUser, isLoading: false }, 'res1');
+
+    await waitFor(() => expect(mockedResourceService.getResourceById).toHaveBeenCalledWith('res1'));
+    await waitFor(() => expect(mockedResourceService.getAllTags).toHaveBeenCalled());
+
+    expect(screen.getByRole('heading', { name: /edit resource/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toHaveValue(mockResource.title);
+    expect(screen.getByLabelText(/type/i)).toHaveValue(mockResource.type);
+    expect(screen.getByLabelText(/content data/i)).toHaveValue(mockResource.content_data);
+
+    // Check if TagA is selected (has selected style)
+    const tagAChip = screen.getByText(mockAvailableTags[0].name);
+    expect(tagAChip).toHaveStyle('background-color: #007bff'); // Assuming this is selected style
+  });
+
+  it('updates input fields on change', async () => {
+    renderFormPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => expect(mockedResourceService.getAllTags).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'New Title' } });
+    expect(screen.getByLabelText(/title/i)).toHaveValue('New Title');
+
+    fireEvent.change(screen.getByLabelText(/type/i), { target: { value: ResourceType.VIDEO_URL } });
+    expect(screen.getByLabelText(/type/i)).toHaveValue(ResourceType.VIDEO_URL);
+  });
+
+  it('handles tag selection and new tag input', async () => {
+    renderFormPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => expect(mockedResourceService.getAllTags).toHaveBeenCalled());
+
+    // Select TagB
+    fireEvent.click(screen.getByText(mockAvailableTags[1].name));
+    expect(screen.getByText(mockAvailableTags[1].name)).toHaveStyle('background-color: #007bff');
+
+    // Add new tags
+    fireEvent.change(screen.getByPlaceholderText(/e.g., newTag1, anotherTag/i), { target: { value: 'customTag1, customTag2' } });
+    expect(screen.getByPlaceholderText(/e.g., newTag1, anotherTag/i)).toHaveValue('customTag1, customTag2');
+  });
+
+  it('submits form for creating a new resource', async () => {
+    renderFormPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => expect(mockedResourceService.getAllTags).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Final Title' } });
+    fireEvent.change(screen.getByLabelText(/type/i), { target: { value: ResourceType.MARKDOWN } });
+    fireEvent.change(screen.getByLabelText(/content data/i), { target: { value: '# Markdown Content' } });
+    fireEvent.click(screen.getByText(mockAvailableTags[0].name)); // Select TagA
+    fireEvent.change(screen.getByPlaceholderText(/e.g., newTag1, anotherTag/i), { target: { value: 'newCustom' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /create resource/i }));
+
+    await waitFor(() =>
+      expect(mockedResourceService.createResource).toHaveBeenCalledWith({
+        title: 'Final Title',
+        type: ResourceType.MARKDOWN,
+        content_data: '# Markdown Content',
+        tagIds: [mockAvailableTags[0].id],
+        newTags: ['newCustom'],
+      })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher/resources');
+  });
+
+  it('submits form for updating an existing resource', async () => {
+    renderFormPage({ user: mockTeacherUser, isLoading: false }, 'res1');
+    await waitFor(() => expect(mockedResourceService.getResourceById).toHaveBeenCalledWith('res1'));
+
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Updated Resource Title' } });
+    // Unselect TagA (was initially selected for mockResource) then select TagB
+    fireEvent.click(screen.getByText(mockAvailableTags[0].name));
+    fireEvent.click(screen.getByText(mockAvailableTags[1].name));
+    fireEvent.change(screen.getByPlaceholderText(/e.g., newTag1, anotherTag/i), { target: { value: 'anotherNew' } });
+
+
+    fireEvent.click(screen.getByRole('button', { name: /update resource/i }));
+
+    await waitFor(() =>
+      expect(mockedResourceService.updateResource).toHaveBeenCalledWith('res1', {
+        title: 'Updated Resource Title',
+        type: mockResource.type, // Type wasn't changed in this test
+        content_data: mockResource.content_data, // Content data wasn't changed
+        tagIds: [mockAvailableTags[1].id], // TagA unselected, TagB selected
+        newTags: ['anotherNew'],
+      })
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/teacher/resources');
+  });
+
+  it('displays error message on submission failure', async () => {
+    mockedResourceService.createResource.mockRejectedValueOnce(new Error('Create failed miserably'));
+    renderFormPage({ user: mockTeacherUser, isLoading: false });
+    await waitFor(() => expect(mockedResourceService.getAllTags).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Test' } });
+    fireEvent.click(screen.getByRole('button', { name: /create resource/i }));
+
+    await waitFor(() => expect(screen.getByText(/Create failed miserably/i)).toBeInTheDocument());
+  });
+});

--- a/client/src/pages/teacher/ResourceFormPage.tsx
+++ b/client/src/pages/teacher/ResourceFormPage.tsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect, FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  getResourceById,
+  createResource,
+  updateResource,
+  getAllTags,
+} from '../../services/resourceService';
+import { Resource, ResourceType, Tag, CreateResourcePayload, UpdateResourcePayload } from '../../types/resource';
+import { useAuth } from '../../contexts/AuthContext'; // For teacher role verification if needed again
+
+// Basic styling
+const styles: { [key: string]: React.CSSProperties } = {
+  page: { padding: '20px', maxWidth: '700px', margin: '0 auto', fontFamily: 'Arial, sans-serif' },
+  form: { display: 'flex', flexDirection: 'column', gap: '15px' },
+  formGroup: { display: 'flex', flexDirection: 'column' },
+  label: { marginBottom: '5px', fontWeight: 'bold' },
+  input: { padding: '10px', border: '1px solid #ccc', borderRadius: '4px', fontSize: '1rem' },
+  textarea: { padding: '10px', border: '1px solid #ccc', borderRadius: '4px', fontSize: '1rem', minHeight: '100px' },
+  select: { padding: '10px', border: '1px solid #ccc', borderRadius: '4px', fontSize: '1rem' },
+  button: { padding: '10px 15px', fontSize: '1rem', backgroundColor: '#007bff', color: 'white', border: 'none', borderRadius: '5px', cursor: 'pointer' },
+  error: { color: 'red', marginTop: '10px' },
+  loading: { textAlign: 'center', fontSize: '1.2rem', marginTop: '50px' },
+  tagSelectionContainer: { border: '1px solid #eee', padding: '10px', borderRadius: '4px' },
+  tagCloud: { display: 'flex', flexWrap: 'wrap', gap: '5px', marginBottom: '10px' },
+  tagChip: { padding: '5px 10px', backgroundColor: '#e0e0e0', borderRadius: '15px', cursor: 'pointer', fontSize: '0.9rem' },
+  tagChipSelected: { backgroundColor: '#007bff', color: 'white' },
+  newTagInput: { marginTop: '5px' }
+};
+
+const ResourceFormPage: React.FC = () => {
+  const { resourceId } = useParams<{ resourceId?: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuth(); // Assuming user details are needed, or for role check
+
+  const [title, setTitle] = useState('');
+  const [type, setType] = useState<ResourceType>(ResourceType.TEXT); // Default type
+  const [contentData, setContentData] = useState(''); // Store as string, parse based on type on submit
+
+  const [availableTags, setAvailableTags] = useState<Tag[]>([]);
+  const [selectedTagIds, setSelectedTagIds] = useState<Set<number>>(new Set());
+  const [newTagsString, setNewTagsString] = useState(''); // Comma-separated new tags
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingDetails, setIsFetchingDetails] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isEditMode = Boolean(resourceId);
+
+  useEffect(() => {
+    // Fetch all available tags for selection
+    const fetchTags = async () => {
+      try {
+        const tags = await getAllTags();
+        setAvailableTags(tags);
+      } catch (err) {
+        console.error("Failed to fetch tags:", err);
+        // Optionally set an error state for tags loading
+      }
+    };
+    fetchTags();
+
+    if (isEditMode && resourceId) {
+      setIsFetchingDetails(true);
+      getResourceById(resourceId)
+        .then(resource => {
+          setTitle(resource.title);
+          setType(resource.type);
+          // Assuming content_data is an object, stringify for textarea, or handle based on type
+          setContentData(typeof resource.content_data === 'object' ? JSON.stringify(resource.content_data, null, 2) : String(resource.content_data || ''));
+          if (resource.tags) {
+            setSelectedTagIds(new Set(resource.tags.map(tag => tag.id)));
+          }
+        })
+        .catch(err => {
+          console.error("Failed to fetch resource details:", err);
+          setError("Failed to load resource data. Please try again.");
+        })
+        .finally(() => setIsFetchingDetails(false));
+    }
+  }, [resourceId, isEditMode]);
+
+  const handleTagSelection = (tagId: number) => {
+    setSelectedTagIds(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(tagId)) {
+        newSet.delete(tagId);
+      } else {
+        newSet.add(tagId);
+      }
+      return newSet;
+    });
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    let parsedContentData: any;
+    try {
+        // Attempt to parse content_data if it's likely JSON (e.g. for URL types or structured text)
+        // For simple text or markdown, it might just be the string itself.
+        // This logic might need refinement based on how `content_data` is used per `ResourceType`.
+        if (type === ResourceType.VIDEO_URL || type === ResourceType.IMAGE_URL || type === ResourceType.MODEL_3D_URL) {
+            parsedContentData = { url: contentData.trim() }; // Assuming URL is directly in textarea
+        } else if (type === ResourceType.TEXT && contentData.startsWith('{') && contentData.endsWith('}')) {
+             // A convention if TEXT type might store JSON
+            parsedContentData = JSON.parse(contentData);
+        }
+        else {
+            parsedContentData = contentData; // For MARKDOWN or simple TEXT
+        }
+    } catch (e) {
+        setError("Content data is not valid JSON where expected, or has an issue.");
+        setIsLoading(false);
+        return;
+    }
+
+    const newTagsArray = newTagsString.split(',').map(t => t.trim()).filter(t => t.length > 0);
+
+    const payload: CreateResourcePayload | UpdateResourcePayload = {
+      title,
+      type,
+      content_data: parsedContentData,
+      tagIds: Array.from(selectedTagIds),
+      newTags: newTagsArray,
+    };
+
+    try {
+      if (isEditMode && resourceId) {
+        await updateResource(resourceId, payload as UpdateResourcePayload);
+      } else {
+        await createResource(payload as CreateResourcePayload);
+      }
+      navigate('/teacher/resources'); // Redirect after successful operation
+    } catch (err: any) {
+      setError(err.response?.data?.message || err.message || 'Operation failed. Please try again.');
+      console.error(err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isFetchingDetails) {
+    return <div style={styles.loading}>Loading resource details...</div>;
+  }
+
+  // Optional: Add a check here for user role if TeacherProtectedRoute isn't fully relied upon
+  if (user?.role !== 'teacher') {
+    return <div style={styles.error}>You are not authorized to manage resources.</div>;
+  }
+
+  return (
+    <div style={styles.page}>
+      <h1>{isEditMode ? 'Edit Resource' : 'Create New Resource'}</h1>
+      <form onSubmit={handleSubmit} style={styles.form}>
+        <div style={styles.formGroup}>
+          <label htmlFor="title" style={styles.label}>Title:</label>
+          <input type="text" id="title" value={title} onChange={e => setTitle(e.target.value)} required style={styles.input} />
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="type" style={styles.label}>Type:</label>
+          <select id="type" value={type} onChange={e => setType(e.target.value as ResourceType)} style={styles.select}>
+            {Object.values(ResourceType).map(rt => (
+              <option key={rt} value={rt}>{rt.replace('_', ' ').toUpperCase()}</option>
+            ))}
+          </select>
+        </div>
+
+        <div style={styles.formGroup}>
+          <label htmlFor="contentData" style={styles.label}>Content Data:</label>
+          <textarea id="contentData" value={contentData} onChange={e => setContentData(e.target.value)} style={styles.textarea}
+            placeholder={
+                type === ResourceType.IMAGE_URL || type === ResourceType.VIDEO_URL || type === ResourceType.MODEL_3D_URL ? "Enter URL here" :
+                type === ResourceType.MARKDOWN ? "Enter Markdown text" :
+                type === ResourceType.TEXT ? "Enter simple text or JSON for structured content" : "Enter content"
+            }
+          />
+           { (type === ResourceType.IMAGE_URL || type === ResourceType.VIDEO_URL || type === ResourceType.MODEL_3D_URL) &&
+             <small>Please enter a direct URL.</small> }
+           { type === ResourceType.TEXT &&
+             <small>For structured content, you can use JSON format. E.g., {"{\"key\":\"value\"}"}</small> }
+
+        </div>
+
+        <div style={styles.formGroup}>
+          <label style={styles.label}>Tags:</label>
+          <div style={styles.tagSelectionContainer}>
+            <p>Select existing tags:</p>
+            <div style={styles.tagCloud}>
+              {availableTags.map(tag => (
+                <span
+                  key={tag.id}
+                  style={{...styles.tagChip, ...(selectedTagIds.has(tag.id) ? styles.tagChipSelected : {})}}
+                  onClick={() => handleTagSelection(tag.id)}
+                >
+                  {tag.name}
+                </span>
+              ))}
+              {availableTags.length === 0 && <small>No existing tags found.</small>}
+            </div>
+            <p>Add new tags (comma-separated):</p>
+            <input
+              type="text"
+              value={newTagsString}
+              onChange={e => setNewTagsString(e.target.value)}
+              placeholder="e.g., newTag1, anotherTag"
+              style={{...styles.input, ...styles.newTagInput}}
+            />
+          </div>
+        </div>
+
+        {error && <p style={styles.error}>{error}</p>}
+
+        <button type="submit" disabled={isLoading} style={styles.button}>
+          {isLoading ? (isEditMode ? 'Updating...' : 'Creating...') : (isEditMode ? 'Update Resource' : 'Create Resource')}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ResourceFormPage;

--- a/client/src/services/resourceService.ts
+++ b/client/src/services/resourceService.ts
@@ -1,0 +1,96 @@
+import api from './api'; // Import the configured Axios instance
+import { Resource, CreateResourcePayload, UpdateResourcePayload } from '../types/resource';
+
+// Fetch resources authored by the currently logged-in teacher
+export const getMyResources = async (): Promise<Resource[]> => {
+  try {
+    const response = await api.get<Resource[]>('/resources/teacher/my-resources');
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch my resources:', error);
+    // Consider throwing a custom error or returning a structure that indicates error
+    throw error;
+  }
+};
+
+// Fetch all resources (publicly, or based on user role if backend filters)
+// This is similar to courseService.getAllCourses
+export const getAllResources = async (queryParams?: { tag?: string; type?: string; teacherId?: number }): Promise<Resource[]> => {
+  try {
+    const response = await api.get<Resource[]>('/resources', { params: queryParams });
+    return response.data;
+  } catch (error) {
+    console.error('Failed to fetch all resources:', error);
+    throw error;
+  }
+};
+
+// Fetch a single resource by its ID
+export const getResourceById = async (resourceId: string): Promise<Resource> => {
+  try {
+    const response = await api.get<Resource>(`/resources/${resourceId}`);
+    return response.data;
+  } catch (error) {
+    console.error(`Failed to fetch resource with ID ${resourceId}:`, error);
+    throw error;
+  }
+};
+
+// Create a new resource
+export const createResource = async (payload: CreateResourcePayload): Promise<Resource> => {
+  try {
+    const response = await api.post<Resource>('/resources', payload);
+    return response.data;
+  } catch (error) {
+    console.error('Failed to create resource:', error);
+    throw error;
+  }
+};
+
+// Update an existing resource
+export const updateResource = async (resourceId: string, payload: UpdateResourcePayload): Promise<Resource> => {
+  try {
+    const response = await api.patch<Resource>(`/resources/${resourceId}`, payload);
+    return response.data;
+  } catch (error) {
+    console.error(`Failed to update resource with ID ${resourceId}:`, error);
+    throw error;
+  }
+};
+
+// Delete a resource
+export const deleteResource = async (resourceId: string): Promise<void> => {
+  try {
+    await api.delete(`/resources/${resourceId}`);
+  } catch (error) {
+    console.error(`Failed to delete resource with ID ${resourceId}:`, error);
+    throw error;
+  }
+};
+
+// --- Tag related services (can be in a separate tagService.ts if grows complex) ---
+import { Tag } from '../types/resource'; // Re-import if moved to separate file
+
+export const getAllTags = async (): Promise<Tag[]> => {
+    try {
+        const response = await api.get<Tag[]>('/tags');
+        return response.data;
+    } catch (error) {
+        console.error('Failed to fetch tags:', error);
+        throw error;
+    }
+};
+
+// Fetch resources linked to a specific chapter
+export const getResourcesForChapter = async (courseId: string | number, chapterId: string | number): Promise<Resource[]> => {
+  try {
+    // Note: The backend API is GET /courses/:courseId/chapters/:chapterId/resources
+    // This service function is placed in resourceService.ts for convenience as it returns Resource[]
+    // It could also logically fit in a courseService.ts or chapterService.ts
+    const response = await api.get<Resource[]>(`/courses/${courseId}/chapters/${chapterId}/resources`);
+    return response.data;
+  } catch (error) {
+    console.error(`Failed to fetch resources for chapter ID ${chapterId} of course ID ${courseId}:`, error);
+    throw error;
+  }
+};

--- a/client/src/types/resource.ts
+++ b/client/src/types/resource.ts
@@ -1,0 +1,46 @@
+// Matches ResourceType enum in backend (resource.entity.ts)
+export enum ResourceType {
+  TEXT = 'text',
+  IMAGE_URL = 'image_url',
+  VIDEO_URL = 'video_url',
+  MARKDOWN = 'markdown',
+  QUIZ_REF = 'quiz_ref',
+  MODEL_3D_URL = '3d_model_url',
+}
+
+// Basic Tag interface, expand if needed
+export interface Tag {
+  id: number;
+  name: string;
+}
+
+// Basic User interface for teacher details, expand if needed
+export interface BasicUser {
+    id: number;
+    username: string;
+    firstName?: string;
+    lastName?: string;
+}
+
+export interface Resource {
+  id: string; // Assuming UUID from backend
+  title: string;
+  type: ResourceType;
+  content_data?: any; // Flexible based on type, e.g., { text: "..." }, { url: "..." }
+  teacherId: number;
+  teacher?: BasicUser; // Optional: if backend populates teacher details
+  tags?: Tag[]; // Optional: if backend populates tags
+  createdAt: string; // ISO date string
+  updatedAt: string; // ISO date string
+}
+
+// For DTOs if needed on frontend, e.g., CreateResourcePayload
+export interface CreateResourcePayload {
+  title: string;
+  type: ResourceType;
+  content_data?: any;
+  tagIds?: number[];
+  newTags?: string[];
+}
+
+export interface UpdateResourcePayload extends Partial<CreateResourcePayload> {}

--- a/server/src/database/migrations/1677600001000-LinkResourcesToChapters.ts
+++ b/server/src/database/migrations/1677600001000-LinkResourcesToChapters.ts
@@ -1,0 +1,84 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableUnique } from "typeorm";
+
+export class LinkResourcesToChapters1677600001000 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(new Table({
+            name: "chapter_content_units",
+            columns: [
+                {
+                    name: "id",
+                    type: "uuid",
+                    isPrimary: true,
+                    isGenerated: true,
+                    generationStrategy: "uuid",
+                },
+                {
+                    name: "chapterId",
+                    type: "int", // Assuming Chapter ID is int
+                },
+                {
+                    name: "resourceId",
+                    type: "uuid", // Assuming Resource ID is uuid
+                },
+                {
+                    name: "order",
+                    type: "int",
+                },
+                {
+                    name: "createdAt",
+                    type: "timestamp with time zone",
+                    default: "CURRENT_TIMESTAMP",
+                },
+                {
+                    name: "updatedAt",
+                    type: "timestamp with time zone",
+                    default: "CURRENT_TIMESTAMP",
+                    onUpdate: "CURRENT_TIMESTAMP",
+                },
+            ],
+        }), true);
+
+        // Foreign key to chapters table
+        await queryRunner.createForeignKey("chapter_content_units", new TableForeignKey({
+            columnNames: ["chapterId"],
+            referencedColumnNames: ["id"],
+            referencedTableName: "chapters", // Make sure this matches your chapters table name
+            onDelete: "CASCADE", // If a chapter is deleted, remove its content unit entries
+        }));
+
+        // Foreign key to resources table
+        await queryRunner.createForeignKey("chapter_content_units", new TableForeignKey({
+            columnNames: ["resourceId"],
+            referencedColumnNames: ["id"],
+            referencedTableName: "resources", // Make sure this matches your resources table name
+            onDelete: "CASCADE", // If a resource is deleted, remove its links to chapters
+        }));
+
+        // Unique constraint for (chapterId, resourceId)
+        await queryRunner.createUniqueConstraint("chapter_content_units", new TableUnique({
+            name: "UQ_chapter_resource", // Optional: specify a name for the unique constraint
+            columnNames: ["chapterId", "resourceId"],
+        }));
+
+        // Optional: If (chapterId, order) should be unique instead of (chapterId, resourceId)
+        // await queryRunner.createUniqueConstraint("chapter_content_units", new TableUnique({
+        //     name: "UQ_chapter_order",
+        //     columnNames: ["chapterId", "order"],
+        // }));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop unique constraints first if they were named, otherwise TypeORM might handle by table.
+        // await queryRunner.dropUniqueConstraint("chapter_content_units", "UQ_chapter_resource");
+        // await queryRunner.dropUniqueConstraint("chapter_content_units", "UQ_chapter_order"); // if created
+
+        // Drop foreign keys - TypeORM might handle these if not named, or drop by table.
+        // It's safer to drop them explicitly if they were named or if you know the convention.
+        // Example: await queryRunner.dropForeignKey("chapter_content_units", "FK_content_unit_chapter");
+        // Example: await queryRunner.dropForeignKey("chapter_content_units", "FK_content_unit_resource");
+
+        await queryRunner.dropTable("chapter_content_units");
+    }
+
+}

--- a/server/src/modules/courses/controllers/courses.controller.spec.ts
+++ b/server/src/modules/courses/controllers/courses.controller.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CoursesController } from './courses.controller';
+import { CoursesService } from '../courses.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { User, UserRole } from '../../users/entities/user.entity';
+import { AddResourceToChapterDto } from '../dto/add-resource-to-chapter.dto';
+import { UpdateChapterResourceOrderDto, ChapterResourceOrderUpdateItemDto } from '../dto/update-chapter-resource-order.dto';
+import { ChapterContentUnit } from '../entities/chapter-content-unit.entity';
+import { Resource } from '../../resources/entities/resource.entity';
+
+// Mock user for decorator
+const mockUser = (id: number, role: UserRole = UserRole.TEACHER): User => ({
+  id, username: `user${id}`, email: `user${id}@example.com`, role,
+  firstName: 'Test', lastName: 'User', createdAt: new Date(), updatedAt: new Date(),
+  hashPassword: jest.fn(), validatePassword: jest.fn(), courses: [], authoredResources: [],
+});
+
+describe('CoursesController', () => {
+  let controller: CoursesController;
+  let service: CoursesService;
+
+  const mockCoursesService = {
+    addResourceToChapter: jest.fn(),
+    removeResourceFromChapter: jest.fn(),
+    updateResourceOrderInChapter: jest.fn(),
+    getResourcesForChapter: jest.fn(),
+    // Mock other methods used by existing controller tests if any were present
+    createCourse: jest.fn(),
+    findAllCourses: jest.fn(),
+    findCourseById: jest.fn(),
+    findCoursesByTeacher: jest.fn(),
+    updateCourse: jest.fn(),
+    removeCourse: jest.fn(),
+    createChapter: jest.fn(),
+    findChaptersByCourseId: jest.fn(),
+    findChapterById: jest.fn(),
+    updateChapter: jest.fn(),
+    removeChapter: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CoursesController],
+      providers: [
+        { provide: CoursesService, useValue: mockCoursesService },
+      ],
+    })
+    .overrideGuard(JwtAuthGuard).useValue({ canActivate: jest.fn(() => true) }) // Mock guards
+    .overrideGuard(RolesGuard).useValue({ canActivate: jest.fn(() => true) })
+    .compile();
+
+    controller = module.get<CoursesController>(CoursesController);
+    service = module.get<CoursesService>(CoursesService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('addResourceToChapter', () => {
+    it('should call service to add resource to chapter', async () => {
+      const courseId = 1;
+      const chapterId = 1;
+      const dto: AddResourceToChapterDto = { resourceId: 'uuid-res-1', order: 1 };
+      const user = mockUser(1);
+      const expectedResult = { id: 'uuid-ccu-1' } as ChapterContentUnit;
+      mockCoursesService.addResourceToChapter.mockResolvedValue(expectedResult);
+
+      const result = await controller.addResourceToChapter(courseId, chapterId, dto, user);
+      expect(service.addResourceToChapter).toHaveBeenCalledWith(courseId, chapterId, dto, user);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('removeResourceFromChapter', () => {
+    it('should call service to remove resource from chapter', async () => {
+      const courseId = 1;
+      const chapterId = 1;
+      const resourceId = 'uuid-res-1';
+      const user = mockUser(1);
+      mockCoursesService.removeResourceFromChapter.mockResolvedValue(undefined);
+
+      await controller.removeResourceFromChapter(courseId, chapterId, resourceId, user);
+      expect(service.removeResourceFromChapter).toHaveBeenCalledWith(courseId, chapterId, resourceId, user);
+    });
+  });
+
+  describe('updateResourceOrderInChapter', () => {
+    it('should call service to update resource order', async () => {
+      const courseId = 1;
+      const chapterId = 1;
+      const orderItem: ChapterResourceOrderUpdateItemDto = { contentUnitId: 'uuid-ccu-1', order: 1 };
+      const dto: UpdateChapterResourceOrderDto = { orderUpdates: [orderItem] };
+      const user = mockUser(1);
+      const expectedResult = [{ id: 'uuid-ccu-1', order: 1 }] as ChapterContentUnit[];
+      mockCoursesService.updateResourceOrderInChapter.mockResolvedValue(expectedResult);
+
+      const result = await controller.updateResourceOrderInChapter(courseId, chapterId, dto, user);
+      expect(service.updateResourceOrderInChapter).toHaveBeenCalledWith(courseId, chapterId, dto.orderUpdates, user);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('getResourcesForChapter', () => {
+    it('should call service to get resources for a chapter', async () => {
+      const chapterId = 1;
+      const courseId = 1; // courseId from path, though service might not use it if chapterId is globally unique
+      const expectedResult = [{ id: 'uuid-res-1', title: 'Resource 1' }] as Resource[];
+      mockCoursesService.getResourcesForChapter.mockResolvedValue(expectedResult);
+
+      const result = await controller.getResourcesForChapter(chapterId);
+      expect(service.getResourcesForChapter).toHaveBeenCalledWith(chapterId);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/server/src/modules/courses/courses.module.ts
+++ b/server/src/modules/courses/courses.module.ts
@@ -4,13 +4,21 @@ import { CoursesService } from './courses.service';
 import { CoursesController } from './courses.controller';
 import { Course } from './entities/course.entity';
 import { Chapter } from './entities/chapter.entity';
-import { User } from '../users/entities/user.entity'; // Import User entity
-import { AuthModule } from '../auth/auth.module'; // For guards and user context
+import { User } from '../users/entities/user.entity';
+import { AuthModule } from '../auth/auth.module';
+import { ChapterContentUnit } from './entities/chapter-content-unit.entity'; // Import ChapterContentUnit
+import { Resource } from '../resources/entities/resource.entity'; // Import Resource
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Course, Chapter, User]), // Include User here for teacher relations
-    AuthModule, // To make JwtAuthGuard, RolesGuard, and user available
+    TypeOrmModule.forFeature([
+      Course,
+      Chapter,
+      User,
+      ChapterContentUnit, // Add ChapterContentUnit
+      Resource, // Add Resource for validation and linking
+    ]),
+    AuthModule,
   ],
   controllers: [CoursesController],
   providers: [CoursesService],

--- a/server/src/modules/courses/dto/add-resource-to-chapter.dto.ts
+++ b/server/src/modules/courses/dto/add-resource-to-chapter.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, IsNumber, Min } from 'class-validator';
+
+export class AddResourceToChapterDto {
+  @IsString()
+  @IsNotEmpty()
+  // Add IsUUID if your resourceId is a UUID, requires `class-validator` version that supports it well or custom decorator.
+  // For now, IsString is a general validation.
+  resourceId: string;
+
+  @IsNumber()
+  @Min(1) // Order usually starts from 1
+  order: number;
+}

--- a/server/src/modules/courses/dto/update-chapter-resource-order.dto.ts
+++ b/server/src/modules/courses/dto/update-chapter-resource-order.dto.ts
@@ -1,0 +1,24 @@
+import { IsArray, IsNotEmpty, IsNumber, IsString, ValidateNested, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class ChapterResourceOrderUpdateItemDto {
+  @IsString()
+  @IsNotEmpty()
+  // This could be resourceId or chapterContentUnitId depending on how you want to identify the item to reorder.
+  // Using chapterContentUnitId is more precise if you have it.
+  // If using resourceId, ensure it's clear which instance if a resource could appear multiple times (not the case with current unique constraint).
+  // Let's assume chapterContentUnitId for precision.
+  contentUnitId: string; // Assuming ChapterContentUnit ID is UUID
+
+  @IsNumber()
+  @Min(1)
+  order: number;
+}
+
+export class UpdateChapterResourceOrderDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChapterResourceOrderUpdateItemDto)
+  @IsNotEmpty()
+  orderUpdates: ChapterResourceOrderUpdateItemDto[];
+}

--- a/server/src/modules/courses/entities/chapter-content-unit.entity.ts
+++ b/server/src/modules/courses/entities/chapter-content-unit.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Chapter } from './chapter.entity';
+import { Resource } from '../../resources/entities/resource.entity';
+
+@Entity('chapter_content_units')
+@Unique(['chapter', 'resource']) // Ensures a resource can only be added once to a specific chapter
+// If you want to allow a resource multiple times with different orders, remove this and make (chapterId, order) unique.
+// @Unique(['chapter', 'order']) // Alternative: ensure order is unique within a chapter
+export class ChapterContentUnit {
+  @PrimaryGeneratedColumn('uuid') // Using UUID for the join record ID itself
+  id: string;
+
+  @Column()
+  chapterId: number;
+
+  @Column('uuid') // Matches Resource ID type
+  resourceId: string;
+
+  @Column('int')
+  order: number; // Defines the sequence of the resource within the chapter
+
+  @ManyToOne(() => Chapter, (chapter) => chapter.contentUnits, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'chapterId' })
+  chapter: Chapter;
+
+  @ManyToOne(() => Resource, (resource) => resource.chapterUsages, { onDelete: 'CASCADE' }) // Cascade delete if resource is deleted
+  @JoinColumn({ name: 'resourceId' })
+  resource: Resource;
+
+  @CreateDateColumn({ type: 'timestamp with time zone', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+}

--- a/server/src/modules/courses/entities/chapter.entity.ts
+++ b/server/src/modules/courses/entities/chapter.entity.ts
@@ -6,8 +6,10 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  OneToMany, // Added OneToMany
 } from 'typeorm';
 import { Course } from './course.entity';
+import { ChapterContentUnit } from './chapter-content-unit.entity'; // Import ChapterContentUnit
 
 @Entity('chapters')
 export class Chapter {
@@ -35,4 +37,7 @@ export class Chapter {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @OneToMany(() => ChapterContentUnit, (contentUnit) => contentUnit.chapter, { cascade: true })
+  contentUnits: ChapterContentUnit[];
 }

--- a/server/src/modules/resources/controllers/resources.controller.spec.ts
+++ b/server/src/modules/resources/controllers/resources.controller.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ResourcesController } from './resources.controller';
+import { ResourcesService } from '../services/resources.service';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { User, UserRole } from '../../users/entities/user.entity';
+import { CreateResourceDto } from '../dto/create-resource.dto';
+import { Resource, ResourceType } from '../entities/resource.entity';
+
+const mockUser = (id: number, role: UserRole = UserRole.TEACHER): User => ({
+  id, username: `user${id}`, email: `user${id}@example.com`, role,
+  firstName: 'Test', lastName: 'User', createdAt: new Date(), updatedAt: new Date(),
+  hashPassword: jest.fn(), validatePassword: jest.fn(), courses: [], authoredResources: [],
+});
+
+describe('ResourcesController', () => {
+  let controller: ResourcesController;
+  let service: ResourcesService;
+
+  const mockResourcesService = {
+    createResource: jest.fn(),
+    findAllResources: jest.fn(),
+    findResourceById: jest.fn(),
+    findResourcesByTeacher: jest.fn(),
+    updateResource: jest.fn(),
+    removeResource: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourcesController],
+      providers: [{ provide: ResourcesService, useValue: mockResourcesService }],
+    })
+    .overrideGuard(JwtAuthGuard).useValue({ canActivate: jest.fn(() => true) })
+    .overrideGuard(RolesGuard).useValue({ canActivate: jest.fn(() => true) })
+    .compile();
+
+    controller = module.get<ResourcesController>(ResourcesController);
+    service = module.get<ResourcesService>(ResourcesService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('createResource', () => {
+    it('should call service to create a resource', async () => {
+      const dto: CreateResourceDto = { title: 'Test', type: ResourceType.TEXT, content_data: {} };
+      const user = mockUser(1);
+      const expectedResult = { id: 'uuid-1' } as Resource;
+      mockResourcesService.createResource.mockResolvedValue(expectedResult);
+
+      const result = await controller.createResource(dto, user);
+      expect(service.createResource).toHaveBeenCalledWith(dto, user);
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  describe('findAllResources', () => {
+    it('should call service to find all resources', async () => {
+      const expectedResult = [{ id: 'uuid-1' }] as Resource[];
+      mockResourcesService.findAllResources.mockResolvedValue(expectedResult);
+      const result = await controller.findAllResources();
+      expect(service.findAllResources).toHaveBeenCalled();
+      expect(result).toEqual(expectedResult);
+    });
+  });
+
+  // Add similar basic tests for other endpoints:
+  // findResourceById, findMyTeachingResources, updateResource, removeResource
+  // to ensure they call the respective service methods.
+});

--- a/server/src/modules/resources/controllers/tags.controller.spec.ts
+++ b/server/src/modules/resources/controllers/tags.controller.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagsController } from './tags.controller';
+import { TagsService } from '../services/tags.service';
+import { Tag } from '../entities/tag.entity';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+
+describe('TagsController', () => {
+  let controller: TagsController;
+  let service: TagsService;
+
+  const mockTagsService = {
+    getAllTags: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagsController],
+      providers: [{ provide: TagsService, useValue: mockTagsService }],
+    })
+    // If getAllTags is protected, mock JwtAuthGuard here
+    // .overrideGuard(JwtAuthGuard).useValue({ canActivate: jest.fn(() => true) })
+    .compile();
+
+    controller = module.get<TagsController>(TagsController);
+    service = module.get<TagsService>(TagsService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getAllTags', () => {
+    it('should call service to get all tags', async () => {
+      const expectedResult = [{ id: 1, name: 'Tag1' }] as Tag[];
+      mockTagsService.getAllTags.mockResolvedValue(expectedResult);
+
+      const result = await controller.getAllTags();
+      expect(service.getAllTags).toHaveBeenCalled();
+      expect(result).toEqual(expectedResult);
+    });
+  });
+});

--- a/server/src/modules/resources/entities/resource.entity.ts
+++ b/server/src/modules/resources/entities/resource.entity.ts
@@ -8,9 +8,11 @@ import {
   ManyToMany,
   JoinTable,
   JoinColumn,
+  OneToMany, // Added OneToMany
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Tag } from './tag.entity';
+import { ChapterContentUnit } from '../../courses/entities/chapter-content-unit.entity'; // Import ChapterContentUnit
 
 export enum ResourceType {
   TEXT = 'text',
@@ -60,4 +62,7 @@ export class Resource {
 
   @UpdateDateColumn({ type: 'timestamp with time zone', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
   updatedAt: Date;
+
+  @OneToMany(() => ChapterContentUnit, (contentUnit) => contentUnit.resource)
+  chapterUsages: ChapterContentUnit[];
 }


### PR DESCRIPTION
This commit introduces features for you to manage your "活页" (Living Page) resources and lays the groundwork for associating these resources with course chapters.

Key accomplishments in this phase include:

Backend (NestJS):
- I designed and implemented database schema changes (via migration file) to link Resources (活页) to Course Chapters using a 'ChapterContentUnit' join entity. This includes an 'order' field for sequencing.
- I developed initial API endpoints and service logic for adding, removing, reordering, and listing resources associated with chapters.
- I reviewed and confirmed existing Resource/Tag APIs.
- I augmented unit/integration tests for new chapter-resource linking logic and controllers.

Frontend (React):
- I developed a dedicated section for you to manage your "活页" resources:
    - List, view, create, edit, and delete "活页" resources.
    - Implemented a form for resource creation/editing, including a tagging interface (selecting existing tags and adding new ones).
- I created a basic UI for you to view resources currently linked to a specific course chapter (read-only).
- I added placeholder UI elements for future functionality to add/manage resources within chapters.
- I implemented protected routes for teacher-specific views.
- I augmented unit tests for new components and functionality (resource list, forms, chapter content view).

This phase significantly enhances the platform's capabilities by providing you with the tools to build and manage your library of reusable "活页" content, a core concept from the PRD.